### PR TITLE
Set icon background color for Windows 8 tiles

### DIFF
--- a/root/Git Bash.VisualElementsManifest.xml
+++ b/root/Git Bash.VisualElementsManifest.xml
@@ -1,0 +1,6 @@
+<Application xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<VisualElements
+		BackgroundColor="#F0EFE7"
+		ShowNameOnSquare150x150Logo="on"
+		ForegroundText="light"/>
+</Application>


### PR DESCRIPTION
Windows 8.1 automatically determines the background color, which is not always sensible.
The background is also orange, which gives no contrast to the main content.
![win8gittile3](https://cloud.githubusercontent.com/assets/791115/5602481/3a7335e0-938b-11e4-9b1c-2ce2bf51cbce.png)

With this patch, a fixed background color is set. This makes the main content more clear.
![win8gittile4](https://cloud.githubusercontent.com/assets/791115/5602482/450dcbaa-938b-11e4-92c5-237153392631.png)
