### PR TITLE
profile: Remove the current directory (".") from PATH

### DIFF
--- a/root/etc/profile
+++ b/root/etc/profile
@@ -16,9 +16,9 @@ fi
 # I filter the PATH value setting in order to get ready for self hosting the
 # MSYS runtime and wanting different paths searched first for files.
 if [ $MSYSTEM == MINGW32 ]; then
-  export PATH=".:/usr/local/bin:/mingw/bin:/bin:$PATH"
+  export PATH="/usr/local/bin:/mingw/bin:/bin:$PATH"
 else
-  export PATH=".:/usr/local/bin:/bin:/mingw/bin:$PATH"
+  export PATH="/usr/local/bin:/bin:/mingw/bin:$PATH"
 fi
 
 if [ -z "$USERNAME" ]; then


### PR DESCRIPTION
While this is the default in Windows, it is not on Unix, and MSYS is about
Unix after all. Moreover, this has been requested several times by users,
see e.g. [1]. Finally, having "." in PATH is particularly annoying if
there is a locally compiled "git.exe" in the root of the repository in the
"git" directory, as Git commands in that directory would then invoke
"/git/git.exe" instead of "/mingw/bin/git.exe".

[1] https://github.com/msysgit/msysgit/issues/248

Signed-off-by: Sebastian Schuberth <sschuberth@gmail.com>