### PR TITLE
installer: Require mingw32-curl for building cURL

### DIFF
--- a/installer/installer.iss
+++ b/installer/installer.iss
@@ -104,6 +104,7 @@ const
                         + 'msys-rebase '
                         + 'msys-xmlto '
 
+                        + 'mingw32-curl '
                         + 'mingw32-gcc '
                         + 'mingw32-gcc-g++ '
                         + 'mingw32-gettext '


### PR DESCRIPTION
Building cURL depends on cURL (doh) as "mk-ca-bundle.pl" has

    my $curl = `curl -V`;

So install cURL by default, also as it is going to become our download
tool of choice for mgwport.

Signed-off-by: Sebastian Schuberth <sschuberth@gmail.com>